### PR TITLE
GHA: Do not fail fast in matrix tests + CI hygiene

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch all history
           fetch-depth: '0'

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -10,7 +10,7 @@ on:
       plone-version:
         required: false
         type: string
-        default: "6.1.2"
+        default: "6.1.4"
     outputs:
       backend:
         description: "Flag reporting if we should run the backend jobs"

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compute several vars needed for the CI
         id: vars
@@ -47,7 +47,7 @@ jobs:
           echo "base-tag=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "plone-version=${{ inputs.plone-version }}" >> $GITHUB_OUTPUT
 
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
     needs:
       - config
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.13", "3.12", "3.11", "3.10"]
         plone-version: ["6.1-latest", "6.0-latest"]

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,13 @@ BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 ifdef PLONE_VERSION
 PLONE_VERSION := $(PLONE_VERSION)
 else
-PLONE_VERSION := 6.1.2
+PLONE_VERSION := 6.1.4
+endif
+
+ifdef CI
+UV_VENV_ARGS :=
+else
+UV_VENV_ARGS := --python=3.12
 endif
 
 PLONE_SITE_ID?=Plone
@@ -69,7 +75,7 @@ requirements-mxdev.txt: ## Generate constraints file
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"
-	@uv venv $(VENV_FOLDER)
+	@if [[ -d "$(VENV_FOLDER)" ]]; then echo "$(YELLOW)==> Environment already exists at $(VENV_FOLDER)$(RESET)"; else uv venv $(UV_VENV_ARGS) $(VENV_FOLDER); fi
 	@uv pip install -r requirements-mxdev.txt
 
 .PHONY: sync

--- a/news/+gha-actions-bump.internal
+++ b/news/+gha-actions-bump.internal
@@ -1,0 +1,1 @@
+Bumped `actions/checkout` to v6 and `dorny/paths-filter` to v4.0.1 in the CI workflows. @ericof

--- a/news/+makefile-dev-env.internal
+++ b/news/+makefile-dev-env.internal
@@ -1,0 +1,1 @@
+Bumped local default Plone version to 6.1.4 (matching CI) and made the `uv venv` step idempotent, pinning Python 3.12 outside CI. @ericof

--- a/news/+plone-6.1.4.internal
+++ b/news/+plone-6.1.4.internal
@@ -1,0 +1,1 @@
+Bumped default Plone version used in CI to 6.1.4. @ericof

--- a/news/12.internal
+++ b/news/12.internal
@@ -1,0 +1,1 @@
+Disabled fail-fast in the GitHub Actions test matrix so a single cell failure no longer cancels the other Python/Plone combinations. @ericof


### PR DESCRIPTION
## Summary

CI hygiene for the GitHub Actions workflows:

- Disabled `fail-fast` on the test matrix so a single Python/Plone cell failure no longer cancels the rest of the matrix.
- Bumped the default Plone version used by CI from 6.1.2 to 6.1.4.
- Bumped `actions/checkout` to v6 and `dorny/paths-filter` to v4.0.1 across the affected workflows.

Closes #12

## Test plan

- [ ] CI matrix runs to completion across all Python/Plone combinations (no early cancellation).
- [ ] `config` workflow resolves the new default Plone version (6.1.4) when called without an explicit input.
- [ ] `changelog` and `config` workflows succeed with the bumped action versions.